### PR TITLE
remove 'scala-indent:indent-on-parentheses in preference of smartparens

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,16 @@ in most files:
 (scala-mode:goto-start-of-code)
 ```
 
+## Auto parentheses formatting
+
+We recommend using [smartparens](https://github.com/Fuco1/smartparens) to
+automatically format parentheses on insertion, e.g. with
+
+```elisp
+  (sp-local-pair 'scala-mode "(" nil :post-handlers '(("||\n[i]" "RET")))
+  (sp-local-pair 'scala-mode "{" nil :post-handlers '(("||\n[i]" "RET") ("| " "SPC")))
+```
+
 ## Other features
 - highlights only properly formatted string and character constants
 - indenting a code line removes trailing whitespace

--- a/scala-mode2-indent.el
+++ b/scala-mode2-indent.el
@@ -841,11 +841,6 @@ comment is outside the comment region. "
          (+ (match-beginning 0) 1)))
       (current-column))))
 
-(defun scala-indent:indent-on-parentheses ()
-  (when (and (= (char-syntax (char-before)) ?\))
-             (= (save-excursion (back-to-indentation) (point)) (1- (point))))
-    (scala-indent:indent-line)))
-
 (defconst scala-indent:indent-on-words-re
   (concat "^\\s *"
           (regexp-opt '("catch" "case" "else" "finally" "yield") 'words)))

--- a/scala-mode2-map.el
+++ b/scala-mode2-map.el
@@ -13,8 +13,6 @@
 
 (defun scala-mode-map:add-self-insert-hooks ()
   (add-hook 'post-self-insert-hook
-            'scala-indent:indent-on-parentheses)
-  (add-hook 'post-self-insert-hook
             'scala-indent:indent-on-special-words)
   (add-hook 'post-self-insert-hook
             'scala-indent:indent-on-scaladoc-asterisk)


### PR DESCRIPTION
```elisp
  (sp-local-pair 'scala-mode "(" nil :post-handlers '(("||\n[i]" "RET")))
  (sp-local-pair 'scala-mode "{" nil :post-handlers '(("||\n[i]" "RET") ("| " "SPC")))
```

close #99