### PR TITLE
Implemented prettify/conceal with a base set of rules.

### DIFF
--- a/scala-mode2-prettify-symbols.el
+++ b/scala-mode2-prettify-symbols.el
@@ -1,6 +1,8 @@
 ;;; scala-mode-prettify.el - Extension of scala-mode for prettifying scala symbols/code
+;;; scala-mode2-prettify-symbols.el - Extension of scala-mode for prettifying scala symbols/code
 ;;; Copyright (c) 2016 Merlin Göttlinger
 ;;; For information on the License, see the LICENSE file
+;; -*- coding: UTF-8 -*-
 
 (defconst scala-mode-pretty-bool-alist '(
 					 ("<=" . ?≤)

--- a/scala-mode2-prettify-symbols.el
+++ b/scala-mode2-prettify-symbols.el
@@ -51,4 +51,4 @@
 				       scala-mode-pretty-arrows-alist
 				       scala-mode-pretty-misc-alist))
 
-(provide 'scala-mode2-prettify)
+(provide 'scala-mode2-prettify-symbols)

--- a/scala-mode2-prettify-symbols.el
+++ b/scala-mode2-prettify-symbols.el
@@ -1,56 +1,74 @@
-;;; scala-mode-prettify.el - Extension of scala-mode for prettifying scala symbols/code
 ;;; scala-mode2-prettify-symbols.el - Extension of scala-mode for prettifying scala symbols/code
 ;;; Copyright (c) 2016 Merlin Göttlinger
 ;;; For information on the License, see the LICENSE file
 ;; -*- coding: UTF-8 -*-
 
-(defconst scala-mode-pretty-bool-alist '(
-					 ("<=" . ?≤)
-					 (">=" . ?≥)
-					 ("==" . ?≡)
-					 ("!" . ?¬)
-					 ("!=" . ?≢)
-					 ("&&" . ?∧)
-					 ("||" . ?∨)
-					 ("true" . ?⊤)
-					 ("false" . ?⊥)
-					 ("Boolean" . ?𝔹)))
+(defcustom scala-mode-pretty-bool-alist '(
+					  ("<=" . ?≤)
+					  (">=" . ?≥)
+					  ("==" . ?≡)
+					  ("===" . ?≣)
+					  ("!" . ?¬)
+					  ("!=" . ?≢)
+					  ("&&" . ?∧)
+					  ("||" . ?∨)
+					  ("true" . ?⊤)
+					  ("false" . ?⊥)
+					  ("Boolean" . ?𝔹))
+  "Prettify rules for boolean related operations."
+  :type 'alist)
 
-(defconst scala-mode-pretty-collection-alist '(
-					       ("empty" . ?∅)
-					       ("sum" . ?∑)
-					       ("contains" . ?∍)
-					       ("++" . ?⧺)
-					       ("::" . ?⸬)
-					       ("--" . ?╌)))
+(defcustom scala-mode-pretty-collection-alist '(
+						("empty" . ?∅)
+						("sum" . ?∑)
+						("product" . ?∏)
+						("contains" . ?∍)
+						("forall" . ?∀)
+						("any" . ?∃)
+						("intersect" . ?∩)
+						("union" . ?∪)
+						("diff" . ?≏)
+						("subsetOf" . ?⊆)
+						("++" . ?⧺)
+						("::" . ?⸬)
+						("--" . ?╌))
+  "Prettify rules for collections related operations."
+  :type 'alist)
 
-(defconst scala-mode-pretty-arrows-alist'(
-					  ("->" . ?→)
-					  ("<-" . ?←)
-					  ("=>" . ?⇒)
+(defcustom scala-mode-pretty-arrows-alist'(
+					   ("->" . ?→)
+					   ("<-" . ?←)
+					   ("=>" . ?⇒)
 					;("<=" . ?⇐)
-					  ("<=>" . ?⇔)
-					  ("-->" . ?⟶)
-					  ("<->" . ?↔)
-					  ("<--" . ?⟵)
-					  ("<-->" . ?⟷)
-					  ("==>" . ?⟹)
-					  ("<==" . ?⟸)
-					  ("<==>" . ?⟺)
-					  ("~>" . ?⇝)
-					  ("<~" . ?⇜)))
+					   ("<=>" . ?⇔)
+					   ("-->" . ?⟶)
+					   ("<->" . ?↔)
+					   ("<--" . ?⟵)
+					   ("<-->" . ?⟷)
+					   ("==>" . ?⟹)
+					   ("<==" . ?⟸)
+					   ("<==>" . ?⟺)
+					   ("~>" . ?⇝)
+					   ("<~" . ?⇜))
+  "Prettify rules for arrow related code pieces."
+  :type 'alist)
 
-(defconst scala-mode-pretty-misc-alist '(
-					 ("null" . ?∅)
-					 ("Nothing" . ?∅)
-					 ("Unit" . ?∅)
-					 ("Int" . ?ℤ)
-					 (":=" . ?≔)))
+(defcustom scala-mode-pretty-misc-alist '(
+					;("null" . ?∅)
+					;("Nothing" . ?∅)
+					  ("Unit" . ?∅)
+					  ("Int" . ?ℤ)
+					  ("assert" . ?⊦)
+					  (":=" . ?≔))
+  "Prettify rules for other mixed code pieces."
+  :type 'alist)
 
-(defconst scala-mode-pretty-all-alist (append
-				       scala-mode-pretty-bool-alist
-				       scala-mode-pretty-collection-alist
-				       scala-mode-pretty-arrows-alist
-				       scala-mode-pretty-misc-alist))
+(defcustom scala--prettify-symbols-alist (append
+					  scala-mode-pretty-bool-alist
+					  scala-mode-pretty-collection-alist
+					  scala-mode-pretty-arrows-alist
+					  scala-mode-pretty-misc-alist)
+  "All prettify rules to be applied in scala code."
+  :type 'alist)
 
 (provide 'scala-mode2-prettify-symbols)

--- a/scala-mode2-prettify.el
+++ b/scala-mode2-prettify.el
@@ -1,0 +1,54 @@
+;;; scala-mode-prettify.el - Extension of scala-mode for prettifying scala symbols/code
+;;; Copyright (c) 2016 Merlin Göttlinger
+;;; For information on the License, see the LICENSE file
+
+(defconst scala-mode-pretty-bool-alist '(
+					 ("<=" . ?≤)
+					 (">=" . ?≥)
+					 ("==" . ?≡)
+					 ("!" . ?¬)
+					 ("!=" . ?≢)
+					 ("&&" . ?∧)
+					 ("||" . ?∨)
+					 ("true" . ?⊤)
+					 ("false" . ?⊥)
+					 ("Boolean" . ?𝔹)))
+
+(defconst scala-mode-pretty-collection-alist '(
+					       ("empty" . ?∅)
+					       ("sum" . ?∑)
+					       ("contains" . ?∍)
+					       ("++" . ?⧺)
+					       ("::" . ?⸬)
+					       ("--" . ?╌)))
+
+(defconst scala-mode-pretty-arrows-alist'(
+					  ("->" . ?→)
+					  ("<-" . ?←)
+					  ("=>" . ?⇒)
+					;("<=" . ?⇐)
+					  ("<=>" . ?⇔)
+					  ("-->" . ?⟶)
+					  ("<->" . ?↔)
+					  ("<--" . ?⟵)
+					  ("<-->" . ?⟷)
+					  ("==>" . ?⟹)
+					  ("<==" . ?⟸)
+					  ("<==>" . ?⟺)
+					  ("~>" . ?⇝)
+					  ("<~" . ?⇜)))
+
+(defconst scala-mode-pretty-misc-alist '(
+					 ("null" . ?∅)
+					 ("Nothing" . ?∅)
+					 ("Unit" . ?∅)
+					 ("Int" . ?ℤ)
+					 (":=" . ?≔)))
+
+(defconst scala-mode-pretty-all-alist (append
+				       scala-mode-pretty-bool-alist
+				       scala-mode-pretty-collection-alist
+				       scala-mode-pretty-arrows-alist
+				       scala-mode-pretty-misc-alist))
+
+(provide 'scala-mode2-prettify)

--- a/scala-mode2.el
+++ b/scala-mode2.el
@@ -13,6 +13,7 @@
 (require 'scala-mode2-map)
 (require 'scala-mode2-sbt)
 (require 'scala-mode2-imenu)
+(require 'scala-mode2-prettify)
 
 ;; Tested only for emacs 24
 (unless (<= 24 emacs-major-version)
@@ -168,6 +169,12 @@ When started, runs `scala-mode-hook'.
   (add-to-list 'auto-mode-alist
                '("\\.\\(scala\\|sbt\\)\\'" . scala-mode))
   (modify-coding-system-alist 'file "\\.\\(scala\\|sbt\\)\\'" 'utf-8))
+
+(defvar scala--prettify-symbols-alist scala-mode-pretty-all-alist)
+(defun scala-add-pretty ()
+  (setq prettify-symbols-alist scala--prettify-symbols-alist))
+
+(add-hook 'scala-mode-hook 'scala-add-pretty)
 
 (provide 'scala-mode2)
 ;;; scala-mode2.el ends here

--- a/scala-mode2.el
+++ b/scala-mode2.el
@@ -170,11 +170,5 @@ When started, runs `scala-mode-hook'.
                '("\\.\\(scala\\|sbt\\)\\'" . scala-mode))
   (modify-coding-system-alist 'file "\\.\\(scala\\|sbt\\)\\'" 'utf-8))
 
-(defvar scala--prettify-symbols-alist scala-mode-pretty-all-alist)
-(defun scala-add-pretty ()
-  (setq prettify-symbols-alist scala--prettify-symbols-alist))
-
-(add-hook 'scala-mode-hook 'scala-add-pretty)
-
 (provide 'scala-mode2)
 ;;; scala-mode2.el ends here

--- a/scala-mode2.el
+++ b/scala-mode2.el
@@ -13,7 +13,7 @@
 (require 'scala-mode2-map)
 (require 'scala-mode2-sbt)
 (require 'scala-mode2-imenu)
-(require 'scala-mode2-prettify)
+(require 'scala-mode2-prettify-symbols)
 
 ;; Tested only for emacs 24
 (unless (<= 24 emacs-major-version)


### PR DESCRIPTION
What is prettified can be configured by adding or removing from the `scala--prettify-symbols-alist`.