### PR TITLE
add string interpolation

### DIFF
--- a/scala-mode-fontlock.el
+++ b/scala-mode-fontlock.el
@@ -487,6 +487,8 @@ Does not continue past limit.
     (scala-font-lock:mark-floatingPointLiteral . font-lock-constant-face)
     (scala-font-lock:mark-integerLiteral . font-lock-constant-face)
 
+    (scala-syntax:interpolation-matcher 0 font-lock-variable-name-face t)
+
     ))
 
 (defun scala-font-lock:syntactic-face-function (state)

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -155,6 +155,29 @@
           "\\|" scala-syntax:symbolLiteral-re
           "\\|" "null" "\\)"))
 
+(defconst scala-syntax:interpolation-re
+  (concat "\\(" "\\$"  scala-syntax:id-re "\\|" "\\${[^}\n\\\\]*}" "\\)"))
+
+(defun scala-syntax:interpolation-matcher (end)
+  (let* ((pos nil)
+         (syntax nil)
+         (str-start nil)
+         (char-before-str nil))
+    (while (and
+            (setq pos (re-search-forward scala-syntax:interpolation-re end t))
+            (setq syntax (syntax-ppss pos))
+            (if (nth 3 syntax) ;; "is string"
+                (progn
+                  (setq str-start (nth 8 syntax))
+                  ;; s"foo"
+                  ;; ^-- `char-before-str', must be identifier
+                  (setq char-before-str (char-after (1- str-start)))
+                  ;; break if match
+                  (null (string-match-p
+                         scala-syntax:id-re (string char-before-str))))
+              t))) ;; keep going
+    pos))
+
 ;; Paths (Chapter 3.1)
 ;; emacs has a problem with these regex, don't use them
 ;; (defconst scala-syntax:classQualifier-re (concat "[[]" scala-syntax:id-re "[]]"))


### PR DESCRIPTION
Before, scala-mode wouldn't highlight formatter variables, making them a
bit difficult to pick out:

     val s = s"foo $bar"

Now, they're given a different color (`font-lock-variable-name-face`)
than the surrounding string.

Text inside `${}` will be highlighted homogenously (rather than
recursively highlighted as constants, keywords, etc.). This is what
`ruby-mode` does and it's definitely good enough.

Closes #60.

Here's what it looks like in action:


![interpolation](https://cloud.githubusercontent.com/assets/3344958/17619349/a0ae3b44-6039-11e6-9600-c69e808c11d6.png)
