### PR TITLE
add `synchronized` keyword

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -243,7 +243,8 @@ and the empty line")
   (regexp-opt '("abstract" "catch" "case" "class" "def" "do" "else" "final"
                 "finally" "for" "if" "implicit" "import" "lazy" "new" "object"
                 "override" "package" "private" "protected" "return" "sealed"
-                "throw" "trait" "try" "type" "val" "var" "while" "yield")
+                "synchronized" "throw" "trait" "try" "type" "val" "var" "while"
+                "yield")
               'words)
   "Words that we don't want to continue the previous line")
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -286,8 +286,8 @@
   (regexp-opt '("abstract" "case" "catch" "class" "def" "do" "else" "extends"
                 "final" "finally" "for" "forSome" "if" "implicit" "import"
                 "lazy" "match" "new" "object" "override" "package" "private"
-                "protected" "return" "sealed" "throw" "trait" "try" "type"
-                "val" "var" "while" "with" "yield") 'words))
+                "protected" "return" "sealed" "synchronized" "throw" "trait"
+                "try" "type" "val" "var" "while" "with" "yield") 'words))
 
 (defconst scala-syntax:other-keywords-re
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:other-keywords-unsafe-re "\\)"))


### PR DESCRIPTION
Before, the keyword `synchronized` wouldn't get highlighted like all
other keywords. Now, it's highlighted.

---

Before:

![before](https://cloud.githubusercontent.com/assets/3344958/21068638/2a39001e-be28-11e6-88fa-4d8529628ff1.png)

After:

![after](https://cloud.githubusercontent.com/assets/3344958/21068639/2d5925a8-be28-11e6-9df1-dd74de3af13f.png)
