### PR TITLE
Add "inline" keyword from scalameta

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -243,7 +243,7 @@ and the empty line")
   (regexp-opt '("abstract" "catch" "case" "class" "def" "do" "else" "final"
                 "finally" "for" "if" "implicit" "import" "lazy" "new" "object"
                 "override" "package" "private" "protected" "return" "sealed"
-                "throw" "trait" "try" "type" "val" "var" "while" "yield")
+                "throw" "trait" "try" "type" "val" "var" "while" "yield" "inline")
               'words)
   "Words that we don't want to continue the previous line")
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -287,7 +287,7 @@
                 "final" "finally" "for" "forSome" "if" "implicit" "import"
                 "lazy" "match" "new" "object" "override" "package" "private"
                 "protected" "return" "sealed" "throw" "trait" "try" "type"
-                "val" "var" "while" "with" "yield") 'words))
+                "val" "var" "while" "with" "yield" "inline") 'words))
 
 (defconst scala-syntax:other-keywords-re
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:other-keywords-unsafe-re "\\)"))


### PR DESCRIPTION
Enables highlighting for the new `inline` keyword from Scalameta