### PR TITLE
Operator characters ids cannot be adjoint to word constituent ids

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -602,13 +602,16 @@ symbol constituents (syntax 3)."
 
 (defun scala-syntax:propertize-special-symbols (start end)
   (save-excursion
-     (goto-char start)
-     (while (re-search-forward (concat "[" scala-syntax:opchar-group "]" scala-syntax:op-re) end t)
-       (let ((match-beg (match-beginning 0))
-             (match-end (match-end 0))
-             (match (match-string 0)))
-         (unless (member match '("/*" "//" "/**" "</" "*/"))
-           (put-text-property match-beg match-end 'syntax-table '(3 . nil)))))))
+    (goto-char start)
+    (while (re-search-forward (concat "[" scala-syntax:opchar-group "]" scala-syntax:op-re) end t)
+      (let ((match-beg (match-beginning 0))
+            (match-end (match-end 0))
+            (match (match-string 0)))
+        (unless (or
+                 (member match '("/*" "//" "/**" "</" "*/"))
+                 (equal 2 (syntax-class (syntax-after match-end)))
+                 (equal 2 (syntax-class (syntax-after (1- match-beg)))))
+          (put-text-property match-beg match-end 'syntax-table '(3 . nil)))))))
 
 (defun scala-syntax:propertize-quotedid (start end)
   "Mark all `scala-syntax:quotedid-re' as symbol constituents (syntax 3)"

--- a/test/scala-mode-test.el
+++ b/test/scala-mode-test.el
@@ -31,6 +31,7 @@ object Ensime {
     ('font-lock-comment-face "O")
     ('font-lock-comment-delimiter-face "D")
     ('font-lock-doc-face "U")
+    ('font-lock-type-face "T")
     (_ "?")))
 
 (ert-deftest smt:syntax-class-and-font-lock-test-1 ()
@@ -68,3 +69,51 @@ object Ensime {
    "// val |--| = 123"
    "11022203333010222"
    "DDDOOOOOOOOOOOOOO"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-7 ()
+  (smt:test
+   "val xs = 1 :: 2 :: Nil"
+   "2220220102033020330222"
+   "KKK-VV-K-C----C----CCC"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-8 ()
+  (smt:test
+   "val xs = 1:: 2 :: Nil"
+   "222022010211020330222"
+   "KKK-VV-K-C---C----CCC"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-9 ()
+  (smt:test
+   "val xs = 1 ::2 :: Nil"
+   "222022010201120330222"
+   "KKK-VV-K-C---C----CCC"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-10 ()
+  (smt:test
+   "case a :: (2) :: Nil"
+   "22220203304250330222"
+   "KKKK-V-TT--C--CC-TTT"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-11 ()
+  (smt:test
+   "abc :<: def"
+   "22203330222"
+   "--------KKK"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-12 ()
+  (smt:test
+   "Foo<T>"
+   "222121"
+   "CCC-C-"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-13 ()
+  (smt:test
+   "class X[T<:Mapper[T]](t: T){}"
+   "22222024211222222425542102545"
+   "KKKKK-T-CKKCCCCCC-C----K-T---"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-14 ()
+  (smt:test
+   "class X[T <: Mapper[T]](t: T){}"
+   "2222202420330222222425542102545"
+   "KKKKK-T-C-KK-CCCCCC-C----K-T---"))


### PR DESCRIPTION
Fix for issue discussed in https://github.com/ensime/emacs-scala-mode/pull/138#discussion_r119069537