### PR TITLE
Handle $ (dollar char) as punctuation

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -402,9 +402,6 @@
   (regexp-opt '("var" "val" "import") 'words)
   ("Keywords that can start a list"))
 
-(defconst scala-syntax:multiLineStringLiteral-end-re
-  "\"\"+\\(\"\\)")
-
 (defconst scala-syntax:case-re
   "\\<case\\>")
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -616,9 +616,14 @@ symbol constituents (syntax 3)."
   (save-excursion
     (goto-char start)
     (while (re-search-forward scala-syntax:quotedid-re end t)
-      (let ((match-beg (match-beginning 0))
-            (match-end (match-end 0)))
-        (put-text-property match-beg match-end 'syntax-table '(3 . nil))))))
+      (scala-syntax:put-syntax-table-property 0 '(3 . nil)))))
+
+(defun scala-syntax:propertize-dollar (start end)
+  "Mark all $ occurences as punctuation (syntax 1)"
+  (save-excursion
+    (goto-char start)
+    (while (re-search-forward "\\$" end t)
+      (scala-syntax:put-syntax-table-property 0 '(1 . nil)))))
 
 (defun scala-syntax:propertize (start end)
   "See syntax-propertize-function"
@@ -626,7 +631,8 @@ symbol constituents (syntax 3)."
   (scala-syntax:propertize-shell-preamble start end)
   (scala-syntax:propertize-underscore-and-idrest start end)
   (scala-syntax:propertize-special-symbols start end)
-  (scala-syntax:propertize-quotedid start end))
+  (scala-syntax:propertize-quotedid start end)
+  (scala-syntax:propertize-dollar start end))
 
 ;;;;
 ;;;; Syntax navigation functions

--- a/test/scala-mode-test.el
+++ b/test/scala-mode-test.el
@@ -32,6 +32,7 @@ object Ensime {
     ('font-lock-comment-delimiter-face "D")
     ('font-lock-doc-face "U")
     ('font-lock-type-face "T")
+    ('font-lock-string-face "S")
     (_ "?")))
 
 (ert-deftest smt:syntax-class-and-font-lock-test-1 ()
@@ -147,3 +148,21 @@ object Ensime {
    "val c = 1 /////////// big comment"
    "222020102011111111111022202222222"
    "KKK-V-K-C-DDDDDDDDDDDDOOOOOOOOOOO"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-20 ()
+  (smt:test
+   "val c = s\"result $sum\""
+   "2220201027222222012227"
+   "KKK-V-K--SSSSSSSSVVVVS"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-21 ()
+  (smt:test
+   "val c = s\"$sum-123\""
+   "2220201027122212227"
+   "KKK-V-K--SVVVVSSSSS"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-22 ()
+  (smt:test
+   "val c = s\"${sum.getOrElse(\"\")} - $sum\""
+   "22202010271422212222222224775501012227"
+   "KKK-V-K--SSSSSSSSSSSSSSSSSSSSSSSSSSSSS"))


### PR DESCRIPTION
Treating `$` as symbol at syntax-table level leads to bad detection of identifiers in interpolated strings:
<img width="400" alt="highlight-before" src="https://user-images.githubusercontent.com/5246747/27011850-fd5728e8-4ebc-11e7-9b98-4348f81ad7f4.png">

With this change identifiers in interpolated strings are correctly detected:
<img width="397" alt="highlight-after" src="https://user-images.githubusercontent.com/5246747/27011852-02b6bcfe-4ebd-11e7-9606-c9edb052ae52.png">
