### PR TITLE
Fix bad syntax when `*/` is prefixed by an opcode.

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -605,6 +605,7 @@ symbol constituents (syntax 3)."
             (match-end (match-end 0))
             (match (match-string 0)))
         (unless (or
+                 (string-suffix-p "*/" match)
                  (member match '("</"))
                  (member 0 (mapcar (lambda (regexp) (string-match regexp match)) '("^*+/$" "^//.*$" "^/\\*+$")))
                  (equal 2 (syntax-class (syntax-after match-end)))

--- a/test/scala-mode-test.el
+++ b/test/scala-mode-test.el
@@ -166,3 +166,13 @@ object Ensime {
    "val c = s\"${sum.getOrElse(\"\")} - $sum\""
    "22202010271422212222222224775501012227"
    "KKK-V-K--SSSSSSSSSSSSSSSSSSSSSSSSSSSSS"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-23 ()
+  "Test that `[!%&*+/?\\\\^|~-#:<=>@]\*/` will be treated as punctuation and
+_not_ a symbol. Doing so would cause comment strings such as `/* Comment &*/` to
+not be recognized as a delimiter, causing the entire file to treated as a
+comment. A concrete example may be viewed at https://github.com/scala/scala/blob/v2.11.11/src/reflect/scala/reflect/internal/Symbols.scala#L863"
+  (smt:test
+   "/* &*/"
+   "110111"
+   "DDDOOO"))


### PR DESCRIPTION
When `*/` is prefixed by one or more members of `scala-syntax:opchar-group` (`[#:<=>@!%&*+/?\\\\^|~-]`), the `scala-syntax:propertize-special-symbols` function incorrectly marks all the characters as symbol values. This causes the `*/` not to be recognized as a comment terminator.

This commit corrects the issue by adding an exclusion to the `scala-syntax:propertize-special-symbols` function if the `match` value has a suffix of `*/`.

A concrete example can be viewed at https://github.com/scala/scala/blob/v2.11.11/src/reflect/scala/reflect/internal/Symbols.scala#L863 .