### PR TITLE
inline isn't a keyword (was it once?)

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -244,7 +244,7 @@ and the empty line")
   (regexp-opt '("abstract" "catch" "case" "class" "def" "do" "else" "final"
                 "finally" "for" "if" "implicit" "import" "lazy" "new" "object"
                 "override" "package" "private" "protected" "return" "sealed"
-                "throw" "trait" "try" "type" "val" "var" "while" "yield" "inline")
+                "throw" "trait" "try" "type" "val" "var" "while" "yield")
               'words)
   "Words that we don't want to continue the previous line")
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -287,7 +287,7 @@
                 "final" "finally" "for" "forSome" "if" "implicit" "import"
                 "lazy" "match" "new" "object" "override" "package" "private"
                 "protected" "return" "sealed" "throw" "trait" "try" "type"
-                "val" "var" "while" "with" "yield" "inline") 'words))
+                "val" "var" "while" "with" "yield") 'words))
 
 (defconst scala-syntax:other-keywords-re
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:other-keywords-unsafe-re "\\)"))


### PR DESCRIPTION
my codebase suddenly has a bunch of variables called `inline` because of the domain I'm in and I noticed we had it marked as a keyword (it's not).